### PR TITLE
Shreyanalluri/issue15

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,83 @@ Raster to polygon aggregations of gridMET meteorological data. The spatial aggre
 - `vs` `{float64}`: Wind speed at 10 meters (m/s), representing the average daily wind speed at 10 meters above ground level.  
 - `th` `{float64}`: Wind direction at 10 meters (degrees from north), indicating the direction from which the wind is blowing.  
 
+---
+
+# Pipeline Overview
+
+## Data Processing Workflow
+
+The pipeline transforms gridMET raster data (NetCDF format) into aggregated polygon-level statistics through several stages:
+
+### 1. Download (`download_gridmet.py`)
+- Downloads raw gridMET NetCDF files from the [gridMET repository](https://www.climatologylab.org/gridmet.html)
+- One file per variable per year
+- **Output:** `data/{geo_name}/input/raw/{var}_{year}.nc`
+
+### 2. Aggregate (`aggregate_gridmet.py`)
+- Performs zonal statistics to aggregate raster grid cells to polygon boundaries (counties, ZCTAs, or custom shapefiles)
+- Uses weighted averages based on the overlap between grid cells and polygons
+- Processes each variable and year independently
+- **Output:** `data/{geo_name}/intermediate/{var}_{year}_{polygon_name}.parquet`
+
+### 3. Format (`format_gridmet.py`)
+- Joins all meteorological variables into a single daily dataset
+- Ensures data consistency and removes null values
+- Creates a unified time series with all variables for each geographic unit
+- **Output:** `data/{geo_name}/output/daily/meteorology__gridmet__{polygon_name}_daily__{year}.parquet`
+
+### 4. Yearly Aggregates (`get_yearly.py`)
+- Calculates annual average for each meteorological variable
+- Groups by geographic unit (county/ZCTA/grid cell)
+- **Output:** `data/{geo_name}/output/yearly/meteorology__gridmet__{polygon_name}_yearly__{year}.parquet`
+- **Columns:** `{polygon_name}`, `year`, and average values for each gridMET variable
+
+### 5. Seasonal Aggregates (`seasonal_vars.py`)
+- Calculates seasonal averages based on configurable season definitions (see `conf/seasons.yaml`)
+- **Default seasons:**
+  - **Summer:** June, July, August
+  - **Winter:** December, January, February (all from the same calendar year)
+  - Additional seasons can be configured in `conf/seasons.yaml`
+- Each season's variables are prefixed with the season name (e.g., `summer_tmmx`, `winter_pr`)
+- **Output:** `data/{geo_name}/output/seasonal/meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet`
+- **Columns:** `{polygon_name}`, `year`, and seasonal averages (e.g., `summer_tmmx`, `winter_tmmn`, etc.)
+
+## Output Files
+
+All outputs are stored in Parquet format for efficient storage and fast querying:
+
+### Daily Data
+- **Path:** `data/{geo_name}/output/daily/meteorology__gridmet__{polygon_name}_daily__{year}.parquet`
+- **Granularity:** Daily values for each geographic unit
+- **Columns:** Geographic ID, date, and all 11 gridMET variables
+
+### Yearly Data
+- **Path:** `data/{geo_name}/output/yearly/meteorology__gridmet__{polygon_name}_yearly__{year}.parquet`
+- **Granularity:** Annual averages for each geographic unit
+- **Columns:** Geographic ID, year, and mean values for all 11 gridMET variables
+
+### Seasonal Data
+- **Path:** `data/{geo_name}/output/seasonal/meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet`
+- **Granularity:** Seasonal averages for each geographic unit
+- **Columns:** Geographic ID, year, and season-specific mean values (e.g., `summer_tmmx`, `winter_pr`)
+
+## Customizing Seasons
+
+Seasonal definitions are configured in `conf/seasons.yaml`. Each season specifies:
+- `months`: List of month numbers (1=January, 12=December)
+- `year_offset`: Whether to use current year (0) or look back to previous year (-1)
+
+Example configuration:
+```yaml
+summer:
+  months: [6, 7, 8]  # June, July, August
+  year_offset: 0
+
+winter:
+  months: [12, 1, 2]  # December, January, February
+  year_offset: 0       # All from same calendar year
+```
+
 # Run
 
 ## Conda environment

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ The pipeline transforms gridMET raster data (NetCDF format) into aggregated poly
   - **Summer:** June, July, August
   - **Winter:** December, January, February (all from the same calendar year)
   - Additional seasons can be configured in `conf/seasons.yaml`
-- Each season's variables are prefixed with the season name (e.g., `summer_tmmx`, `winter_pr`)
+- Each season's variables are suffixed with the season name (e.g., `tmmx_summer`, `pr_winter`)
 - **Output:** `data/{geo_name}/output/seasonal/meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet`
-- **Columns:** `{polygon_name}`, `year`, and seasonal averages (e.g., `summer_tmmx`, `winter_tmmn`, etc.)
+- **Columns:** `{polygon_name}`, `year`, and seasonal averages (e.g., `tmmx_summer`, `tmmn_winter`, etc.)
 
 ## Output Files
 
@@ -84,7 +84,7 @@ All outputs are stored in Parquet format for efficient storage and fast querying
 ### Seasonal Data
 - **Path:** `data/{geo_name}/output/seasonal/meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet`
 - **Granularity:** Seasonal averages for each geographic unit
-- **Columns:** Geographic ID, year, and season-specific mean values (e.g., `summer_tmmx`, `winter_pr`)
+- **Columns:** Geographic ID, year, and season-specific mean values (e.g., `tmmx_summer`, `pr_winter`)
 
 ## Customizing Seasons
 

--- a/README.md
+++ b/README.md
@@ -90,17 +90,14 @@ All outputs are stored in Parquet format for efficient storage and fast querying
 
 Seasonal definitions are configured in `conf/seasons.yaml`. Each season specifies:
 - `months`: List of month numbers (1=January, 12=December)
-- `year_offset`: Whether to use current year (0) or look back to previous year (-1)
 
 Example configuration:
 ```yaml
 summer:
   months: [6, 7, 8]  # June, July, August
-  year_offset: 0
 
 winter:
   months: [12, 1, 2]  # December, January, February
-  year_offset: 0       # All from same calendar year
 ```
 
 # Run

--- a/Snakefile
+++ b/Snakefile
@@ -36,6 +36,10 @@ rule all:
             f"data/{geo_name}/output/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
             year=years
         ),
+        expand(
+            f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
+            year=years
+        ),
 
 rule download_gridmet:
     output:
@@ -87,3 +91,17 @@ rule get_yearly:
         """
         python src/get_yearly.py year={wildcards.year}
         """
+
+rule get_seasonal:
+    input:
+        current=f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
+        previous=lambda wildcards: f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{int(wildcards.year) - 1}.parquet",
+    output:
+        f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
+    log:
+        f"logs/{geo_name}/get_seasonal_{{year}}.log",
+    shell:
+        """
+        python src/seasonal_vars.py year={wildcards.year} &> {log}
+        """
+

--- a/Snakefile
+++ b/Snakefile
@@ -33,7 +33,7 @@ print(f"geo_name resolved to: {geo_name}")
 rule all:
     input:
         expand(
-            f"data/{geo_name}/output/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
+            f"data/{geo_name}/output/core/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
             year=years
         ),
         expand(
@@ -72,7 +72,7 @@ rule format_gridmet:
             year="{year}"
         ),
     output:
-        f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
+        f"data/{geo_name}/output/core/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     log:
         f"logs/{geo_name}/format_gridmet_{{year}}.log",
     shell:
@@ -82,11 +82,11 @@ rule format_gridmet:
 
 rule get_yearly:
     input:
-        f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
+        f"data/{geo_name}/output/core/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     output:
-        f"data/{geo_name}/output/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
+        f"data/{geo_name}/output/core/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
     log:
-        f"logs/{geo_name}/format_gridmet_{{year}}.log",
+        f"logs/{geo_name}/get_yearly_{{year}}.log",
     shell:
         """
         python src/get_yearly.py year={wildcards.year}
@@ -94,7 +94,7 @@ rule get_yearly:
 
 rule get_seasonal:
     input:
-        f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
+        f"data/{geo_name}/output/core/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     output:
         f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
     log:

--- a/Snakefile
+++ b/Snakefile
@@ -37,7 +37,7 @@ rule all:
             year=years
         ),
         expand(
-            f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
+            f"data/{geo_name}/output/seasonal/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
             year=years
         ),
 
@@ -96,7 +96,7 @@ rule get_seasonal:
     input:
         f"data/{geo_name}/output/core/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     output:
-        f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
+        f"data/{geo_name}/output/seasonal/yearly/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
     log:
         f"logs/{geo_name}/get_seasonal_{{year}}.log",
     shell:

--- a/Snakefile
+++ b/Snakefile
@@ -94,8 +94,7 @@ rule get_yearly:
 
 rule get_seasonal:
     input:
-        current=f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
-        previous=lambda wildcards: f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{int(wildcards.year) - 1}.parquet",
+        f"data/{geo_name}/output/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     output:
         f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
     log:

--- a/Snakefile
+++ b/Snakefile
@@ -96,7 +96,7 @@ rule get_seasonal:
     input:
         f"data/{geo_name}/output/core/daily/meteorology__gridmet__{shapefiles}_daily__{{year}}.parquet",
     output:
-        f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_seasonal__{{year}}.parquet",
+        f"data/{geo_name}/output/seasonal/meteorology__gridmet__{shapefiles}_yearly__{{year}}.parquet",
     log:
         f"logs/{geo_name}/get_seasonal_{{year}}.log",
     shell:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,11 +1,10 @@
 defaults:
   - _self_
-  - datapaths: county_cannon
+  - datapaths: zcta_cannon
   - gridmet
   - snakemake
   - seasons
-  - shapefiles: county   # zcta, county
-
+  - shapefiles: zcta   # zcta, county
 # == aggregation args
 year: 2000
 var: sph  # see the gridmet key in gridmet.yaml for valid options

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,9 +1,10 @@
 defaults:
   - _self_
-  - datapaths: zcta_cannon
+  - datapaths: county_cannon
   - gridmet
   - snakemake
-  - shapefiles: zcta   # zcta, county
+  - seasons
+  - shapefiles: county   # zcta, county
 
 # == aggregation args
 year: 2000

--- a/conf/datapaths/county_cannon.yaml
+++ b/conf/datapaths/county_cannon.yaml
@@ -8,7 +8,9 @@ dirs:
 
   intermediate: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/.county_daily__intermediate
 
-  output: 
-    daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_daily
-    yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_yearly
-    seasonal: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_seasonal
+  output:
+    core: 
+      daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/core/county_daily
+      yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/core/county_yearly
+    seasonal: 
+      yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/seasonal/county_yearly

--- a/conf/datapaths/county_cannon.yaml
+++ b/conf/datapaths/county_cannon.yaml
@@ -11,3 +11,4 @@ dirs:
   output: 
     daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_daily
     yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_yearly
+    seasonal: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/county_seasonal

--- a/conf/datapaths/zcta_cannon.yaml
+++ b/conf/datapaths/zcta_cannon.yaml
@@ -9,6 +9,8 @@ dirs:
   intermediate: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/.zcta_daily__intermediate
 
   output: 
-    daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_daily
-    yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_yearly
-    seasonal: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_seasonal
+    core:
+      daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/core/zcta_daily
+      yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/core/zcta_yearly
+    seasonal: 
+      yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/seasonal/zcta_yearly

--- a/conf/datapaths/zcta_cannon.yaml
+++ b/conf/datapaths/zcta_cannon.yaml
@@ -11,3 +11,4 @@ dirs:
   output: 
     daily: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_daily
     yearly: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_yearly
+    seasonal: /n/dominici_lab/lab/lego/environmental/meteorology__gridmet/zcta_seasonal

--- a/conf/seasons.yaml
+++ b/conf/seasons.yaml
@@ -3,30 +3,29 @@
 # Each season has a name, start month/day, and end month/day
 # For seasons spanning year boundaries (like winter), use year_offset for months in the previous year
 
-seasons:
-  spring:
-    start_month: 3
-    start_day: 1
-    end_month: 5
-    end_day: 31
-    year_offset: 0  # 0 = current year
-  summer:
-    start_month: 6
-    start_day: 1
-    end_month: 8
-    end_day: 31
-    year_offset: 0
-  fall:
-    start_month: 9
-    start_day: 1
-    end_month: 11
-    end_day: 30
-    year_offset: 0
-  winter:
-    # Winter includes December from previous year and Jan-Feb of current year
-    # December is handled with year_offset: -1 to indicate previous year
-    start_month: 12
-    start_day: 1
-    end_month: 2
-    end_day: 29  # Handles leap years automatically in the script
-    year_offset: -1  # December from previous year
+spring:
+  start_month: 3
+  start_day: 1
+  end_month: 5
+  end_day: 31
+  year_offset: 0  # 0 = current year
+summer:
+  start_month: 6
+  start_day: 1
+  end_month: 8
+  end_day: 31
+  year_offset: 0
+fall:
+  start_month: 9
+  start_day: 1
+  end_month: 11
+  end_day: 30
+  year_offset: 0
+winter:
+  # Winter includes December from previous year and Jan-Feb of current year
+  # December is handled with year_offset: -1 to indicate previous year
+  start_month: 12
+  start_day: 1
+  end_month: 2
+  end_day: 29  # Handles leap years automatically in the script
+  year_offset: -1  # December from previous year

--- a/conf/seasons.yaml
+++ b/conf/seasons.yaml
@@ -4,17 +4,12 @@
 # year_offset: 0 = current year, -1 = previous year
 
 summer:
+# June, July, August
   months: [6, 7, 8]
   year_offset: 0
   
 winter:
-  # NEW definition: Dec, Jan, Feb all from the same year
+# Dec, Jan, Feb all from the same year (no lookback to previous year for december)
   months: [12, 1, 2]
   year_offset: 0
   
-  # OLD definition (commented out): Dec from previous year + Jan/Feb from current year
-  # To use this, uncomment below and comment out the NEW definition above:
-  # months: [12]
-  # year_offset: -1
-  # jan_feb_months: [1, 2]
-  # jan_feb_year_offset: 0

--- a/conf/seasons.yaml
+++ b/conf/seasons.yaml
@@ -1,0 +1,32 @@
+# @package seasons
+# Define meteorological seasons for aggregation
+# Each season has a name, start month/day, and end month/day
+# For seasons spanning year boundaries (like winter), use year_offset for months in the previous year
+
+seasons:
+  spring:
+    start_month: 3
+    start_day: 1
+    end_month: 5
+    end_day: 31
+    year_offset: 0  # 0 = current year
+  summer:
+    start_month: 6
+    start_day: 1
+    end_month: 8
+    end_day: 31
+    year_offset: 0
+  fall:
+    start_month: 9
+    start_day: 1
+    end_month: 11
+    end_day: 30
+    year_offset: 0
+  winter:
+    # Winter includes December from previous year and Jan-Feb of current year
+    # December is handled with year_offset: -1 to indicate previous year
+    start_month: 12
+    start_day: 1
+    end_month: 2
+    end_day: 29  # Handles leap years automatically in the script
+    year_offset: -1  # December from previous year

--- a/conf/seasons.yaml
+++ b/conf/seasons.yaml
@@ -1,31 +1,20 @@
 # @package seasons
 # Define meteorological seasons for aggregation
-# Each season has a name, start month/day, and end month/day
-# For seasons spanning year boundaries (like winter), use year_offset for months in the previous year
+# Each season specifies which months to include and the year_offset for those months
+# year_offset: 0 = current year, -1 = previous year
 
-spring:
-  start_month: 3
-  start_day: 1
-  end_month: 5
-  end_day: 31
-  year_offset: 0  # 0 = current year
 summer:
-  start_month: 6
-  start_day: 1
-  end_month: 8
-  end_day: 31
+  months: [6, 7, 8]
   year_offset: 0
-fall:
-  start_month: 9
-  start_day: 1
-  end_month: 11
-  end_day: 30
-  year_offset: 0
+  
 winter:
-  # Winter includes December from previous year and Jan-Feb of current year
-  # December is handled with year_offset: -1 to indicate previous year
-  start_month: 12
-  start_day: 1
-  end_month: 2
-  end_day: 29  # Handles leap years automatically in the script
-  year_offset: -1  # December from previous year
+  # NEW definition: Dec, Jan, Feb all from the same year
+  months: [12, 1, 2]
+  year_offset: 0
+  
+  # OLD definition (commented out): Dec from previous year + Jan/Feb from current year
+  # To use this, uncomment below and comment out the NEW definition above:
+  # months: [12]
+  # year_offset: -1
+  # jan_feb_months: [1, 2]
+  # jan_feb_year_offset: 0

--- a/conf/seasons.yaml
+++ b/conf/seasons.yaml
@@ -1,15 +1,12 @@
 # @package seasons
 # Define meteorological seasons for aggregation
-# Each season specifies which months to include and the year_offset for those months
-# year_offset: 0 = current year, -1 = previous year
+# Each season specifies which months to include
 
 summer:
 # June, July, August
   months: [6, 7, 8]
-  year_offset: 0
   
 winter:
-# Dec, Jan, Feb all from the same year (no lookback to previous year for december)
+# Dec, Jan, Feb all from the same year
   months: [12, 1, 2]
-  year_offset: 0
   

--- a/conf/snakemake.yaml
+++ b/conf/snakemake.yaml
@@ -1,5 +1,5 @@
 # @package snakemake
 gridmet_vars: [sph, vpd, tmmn, tmmx, pr, rmin, rmax, srad, vs, th]
 years: [2000, 2024]
-shapefiles: county  # zcta, county
-datapaths: county_cannon
+shapefiles: zcta  # zcta, county
+datapaths: zcta_cannon

--- a/conf/snakemake.yaml
+++ b/conf/snakemake.yaml
@@ -1,5 +1,5 @@
 # @package snakemake
 gridmet_vars: [sph, vpd, tmmn, tmmx, pr, rmin, rmax, srad, vs, th]
-years: [2021, 2024]
-shapefiles: zcta  # zcta, county
-datapaths: zcta_cannon
+years: [2000, 2024]
+shapefiles: county  # zcta, county
+datapaths: county_cannon

--- a/snakefile.sbatch
+++ b/snakefile.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH -p shared # partition (queue)
+#SBATCH -p hsph # partition (queue)
 #SBATCH -c 6 # number of cores
 #SBATCH --mem 40GB # memory per job
 #SBATCH -t 1-01:00 # time (D-HH:MM)

--- a/snakefile.sbatch
+++ b/snakefile.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH -p hsph # partition (queue)
+#SBATCH -p shared # partition (queue)
 #SBATCH -c 6 # number of cores
 #SBATCH --mem 40GB # memory per job
 #SBATCH -t 1-01:00 # time (D-HH:MM)

--- a/src/format_gridmet.py
+++ b/src/format_gridmet.py
@@ -69,7 +69,7 @@ def main(cfg):
                  FROM gridmet
                  ORDER BY date, {cfg.polygon_name}
             ) 
-        TO 'data/{geo_name}/output/daily/meteorology__gridmet__{cfg.polygon_name}_daily__{cfg.year}.parquet'
+        TO 'data/{geo_name}/output/core/daily/meteorology__gridmet__{cfg.polygon_name}_daily__{cfg.year}.parquet'
     """)
 
     # Clean up

--- a/src/get_yearly.py
+++ b/src/get_yearly.py
@@ -24,7 +24,7 @@ def main(cfg):
                 EXTRACT(YEAR FROM date) AS year,
                 {', '.join(gridmet_vars)}
             FROM 
-                'data/{geo_name}/output/daily/meteorology__gridmet__{cfg.polygon_name}_daily__{cfg.year}.parquet'
+                'data/{geo_name}/output/core/daily/meteorology__gridmet__{cfg.polygon_name}_daily__{cfg.year}.parquet'
         )
     """)
 
@@ -56,10 +56,10 @@ def main(cfg):
                  FROM gridmet_yearly_stats
                  ORDER BY year, {cfg.polygon_name}
             ) 
-        TO 'data/{geo_name}/output/yearly/meteorology__gridmet__{cfg.polygon_name}_yearly__{cfg.year}.parquet'
+        TO 'data/{geo_name}/output/core/yearly/meteorology__gridmet__{cfg.polygon_name}_yearly__{cfg.year}.parquet'
     """)
     
-    LOGGER.info(f"Outputted yearly stats table to 'data/{geo_name}/output/yearly/meteorology_{cfg.polygon_name}_yearly_{cfg.year}.parquet'")
+    LOGGER.info(f"Outputted yearly stats table to 'data/{geo_name}/output/core/yearly/meteorology_{cfg.polygon_name}_yearly_{cfg.year}.parquet'")
     conn.close()
 
 if __name__ == "__main__":

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -1,6 +1,5 @@
 """
 Create seasonal aggregates from daily gridMET data for a single year.
-
 This script reads daily parquet files and creates seasonal averages based on
 configurable season definitions from conf/seasons.yaml.
 
@@ -9,8 +8,6 @@ Default seasons:
 - Winter: January 1 - February 28/29 and December 1 - December 31 (of the same year)
 
 adapted from: https://github.com/NSAPH/National-Causal-Analysis/blob/master/Confounders/earth_engine/code/6_calculate_seasonal_averages.R
-
-This script is designed to be orchestrated by Snakemake to process multiple years.
 """
 
 import duckdb
@@ -29,25 +26,23 @@ def build_season_filter(season_name: str, season_config: dict, year: int) -> str
     
     Args:
         season_name: Name of the season (e.g., 'summer', 'winter')
-        season_config: Dictionary with 'months' (list of month numbers) and 'year_offset'
+        season_config: Dictionary with 'months' (list of month numbers)
         year: The year being processed
     
     Returns:
         SQL WHERE clause string
     """
     months = season_config.get('months', [])
-    year_offset = season_config.get('year_offset', 0)
     
     if not months:
         LOGGER.error(f"No months specified for season {season_name}")
         return "1=0"  # Returns no rows
     
-    target_year = year + year_offset
     month_conditions = " OR ".join([f"month = {m}" for m in months])
     
-    LOGGER.info(f"{season_name}: months {months} from year {target_year}")
+    LOGGER.info(f"{season_name}: months {months} from year {year}")
     
-    return f"""data_year = {target_year} AND ({month_conditions})"""
+    return f"""data_year = {year} AND ({month_conditions})"""
 
 
 @hydra.main(config_path="../conf", config_name="config", version_base=None)
@@ -57,14 +52,6 @@ def main(cfg):
     
     This function processes daily gridMET data to create seasonal averages
     based on the seasons defined in cfg.seasons configuration.
-    
-    Args:
-        cfg: Hydra configuration object containing:
-            - year: Year to process (single year)
-            - polygon_name: Geographic identifier column name (e.g., 'zcta', 'county')
-            - datapaths.name: Geographic area name for file paths
-            - snakemake.gridmet_vars: List of gridMET variables to aggregate
-            - seasons: Dictionary of season definitions with start/end months/days
     """
     geo_name = cfg.datapaths.name
     polygon_name = cfg.polygon_name
@@ -136,7 +123,7 @@ def main(cfg):
     # Merge all seasonal data
     LOGGER.info(f"Merging all {len(seasonal_tables)} seasonal aggregates...")
     
-    # Build dynamic JOIN query based on available seasons
+    # Build JOIN query based on available seasons
     season_names = list(seasonal_tables.keys())
     
     if len(season_names) == 0:
@@ -184,10 +171,6 @@ def main(cfg):
     sample = conn.execute("SELECT * FROM seasonal_combined LIMIT 5").fetchdf()
     LOGGER.info(f"\n{sample.to_string()}")
     
-    # Create output directory if it doesn't exist
-    output_dir = Path(f"data/{geo_name}/output/seasonal")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    
     # Write output to parquet file
     output_path = output_dir / f"meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet"
     LOGGER.info(f"Writing output to: {output_path}")
@@ -200,7 +183,6 @@ def main(cfg):
     
     LOGGER.info(f"Seasonal aggregates successfully written to {output_path}")
     
-    # Clean up
     conn.close()
     LOGGER.info("Processing complete!")
 

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -1,15 +1,3 @@
-"""
-Create seasonal aggregates from daily gridMET data for a single year.
-This script reads daily parquet files and creates seasonal averages based on
-configurable season definitions from conf/seasons.yaml.
-
-Default seasons:
-- Summer: June 1 - August 31
-- Winter: January 1 - February 28/29 and December 1 - December 31 (of the same year)
-
-adapted from: https://github.com/NSAPH/National-Causal-Analysis/blob/master/Confounders/earth_engine/code/6_calculate_seasonal_averages.R
-"""
-
 import duckdb
 import hydra
 import logging

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -5,15 +5,10 @@ This script reads daily parquet files and creates seasonal averages based on
 configurable season definitions from conf/seasons.yaml.
 
 Default seasons:
-- Spring: March 1 - May 31
 - Summer: June 1 - August 31
-- Fall: September 1 - November 30
-- Winter: December 1 (previous year) - February 28/29 (current year)
+- Winter: January 1 - February 28/29 and December 1 - December 31 (of the same year)
 
 adapted from: https://github.com/NSAPH/National-Causal-Analysis/blob/master/Confounders/earth_engine/code/6_calculate_seasonal_averages.R
-
-The logic mirrors the R script that processes temperature data, calculating
-mean values for all gridMET variables by geographic unit and season.
 
 This script is designed to be orchestrated by Snakemake to process multiple years.
 """
@@ -30,39 +25,29 @@ LOGGER = logging.getLogger(__name__)
 
 def build_season_filter(season_name: str, season_config: dict, year: int) -> str:
     """
-    Build a SQL WHERE clause filter for a season.
+    Build a SQL WHERE clause filter for a season based on explicit month list.
     
     Args:
         season_name: Name of the season (e.g., 'summer', 'winter')
-        season_config: Dictionary with start_month, start_day, end_month, end_day, year_offset
+        season_config: Dictionary with 'months' (list of month numbers) and 'year_offset'
         year: The year being processed
     
     Returns:
         SQL WHERE clause string
     """
+    months = season_config.get('months', [])
     year_offset = season_config.get('year_offset', 0)
-    start_month = season_config['start_month']
-    end_month = season_config['end_month']
     
-    if year_offset == 0:
-        # Simple case: season within the same year
-        if start_month <= end_month:
-            # Normal season (e.g., summer: June-August)
-            return f"""data_year = {year} 
-              AND month >= {start_month} AND month <= {end_month}"""
-        else:
-            # Season wraps around year boundary within same year (unusual but supported)
-            return f"""data_year = {year} 
-              AND (month >= {start_month} OR month <= {end_month})"""
-    else:
-        # Season spans year boundary (e.g., winter: Dec previous year + Jan-Feb current year)
-        if year_offset == -1:
-            # Previous year contributes to this year's season
-            return f"""(data_year = {year - 1} AND month >= {start_month})
-            OR (data_year = {year} AND month <= {end_month})"""
-        else:
-            LOGGER.warning(f"Unusual year_offset {year_offset} for season {season_name}")
-            return f"data_year = {year} AND month >= {start_month} AND month <= {end_month}"
+    if not months:
+        LOGGER.error(f"No months specified for season {season_name}")
+        return "1=0"  # Returns no rows
+    
+    target_year = year + year_offset
+    month_conditions = " OR ".join([f"month = {m}" for m in months])
+    
+    LOGGER.info(f"{season_name}: months {months} from year {target_year}")
+    
+    return f"""data_year = {target_year} AND ({month_conditions})"""
 
 
 @hydra.main(config_path="../conf", config_name="config", version_base=None)
@@ -93,27 +78,15 @@ def main(cfg):
     
     conn = duckdb.connect()
     
-    # Check which files we need: current year and previous year (for winter)
+    # Load current year data only
     data_dir = Path(f"data/{geo_name}/output/daily")
     current_year_file = data_dir / f"meteorology__gridmet__{polygon_name}_daily__{year}.parquet"
-    prev_year_file = data_dir / f"meteorology__gridmet__{polygon_name}_daily__{year - 1}.parquet"
     
     if not current_year_file.exists():
         LOGGER.error(f"Daily file not found for year {year}: {current_year_file}")
         return
     
-    # Winter calculation needs previous year's December
-    if not prev_year_file.exists():
-        LOGGER.warning(f"Previous year file not found: {prev_year_file}")
-        LOGGER.warning(f"Winter average for {year} will only include Jan-Feb data")
-        files_to_load = [str(current_year_file)]
-    else:
-        files_to_load = [str(prev_year_file), str(current_year_file)]
-    
-    LOGGER.info(f"Loading daily data from: {files_to_load}")
-    
-    # Load data from the necessary files
-    file_list_str = ", ".join([f"'{f}'" for f in files_to_load])
+    LOGGER.info(f"Loading daily data from: {current_year_file}")
     
     conn.execute(f"""
         CREATE OR REPLACE VIEW all_daily_data AS
@@ -124,12 +97,20 @@ def main(cfg):
             EXTRACT(MONTH FROM date) AS month,
             EXTRACT(DAY FROM date) AS day,
             {', '.join(gridmet_vars)}
-        FROM read_parquet([{file_list_str}])
+        FROM read_parquet('{current_year_file}')
     """)
     
     # Check total records
     total_records = conn.execute("SELECT COUNT(*) FROM all_daily_data").fetchone()[0]
     LOGGER.info(f"Total daily records loaded: {total_records:,}")
+    
+    # Log first 10 December dates for verification
+    december_dates = conn.execute("SELECT date FROM all_daily_data WHERE month = 12 ORDER BY date LIMIT 10").fetchall()
+    if december_dates:
+        dates_str = ", ".join([str(d[0]) for d in december_dates])
+        LOGGER.info(f"First 10 December dates: {dates_str}")
+    else:
+        LOGGER.warning("No December dates found in the data")
     
     # Process each configured season
     seasonal_tables = {}
@@ -163,22 +144,43 @@ def main(cfg):
     # Merge all seasonal data
     LOGGER.info(f"Merging all {len(seasonal_tables)} seasonal aggregates...")
     
+    # Build dynamic JOIN query based on available seasons
+    season_names = list(seasonal_tables.keys())
+    
+    if len(season_names) == 0:
+        LOGGER.error("No seasonal tables to merge")
+        return
+    
+    # Build SELECT columns for all seasons
+    select_columns = []
+    for season_name in season_names:
+        season_abbrev = season_name[:2] if len(season_name) >= 2 else season_name[0]
+        select_columns.extend([f'{season_abbrev}.{season_name}_{var}' for var in gridmet_vars])
+    
+    # Build COALESCE for polygon_name across all tables
+    season_abbrevs = [s[:2] if len(s) >= 2 else s[0] for s in season_names]
+    coalesce_expr = f"COALESCE({', '.join([f'{abbrev}.{polygon_name}' for abbrev in season_abbrevs])})"
+    
+    # Build JOIN clause dynamically
+    first_season = season_names[0]
+    first_abbrev = season_abbrevs[0]
+    from_clause = f"FROM {first_season}_aggregates {first_abbrev}"
+    
+    for i in range(1, len(season_names)):
+        season_name = season_names[i]
+        season_abbrev = season_abbrevs[i]
+        prev_abbrevs = season_abbrevs[:i]
+        prev_coalesce = f"COALESCE({', '.join([f'{abbrev}.{polygon_name}' for abbrev in prev_abbrevs])})"
+        from_clause += f"\n        FULL OUTER JOIN {season_name}_aggregates {season_abbrev}\n"
+        from_clause += f"            ON {prev_coalesce} = {season_abbrev}.{polygon_name}"
+    
     conn.execute(f"""
         CREATE OR REPLACE TABLE seasonal_combined AS
         SELECT
-            COALESCE(sp.{polygon_name}, su.{polygon_name}, f.{polygon_name}, w.{polygon_name}) AS {polygon_name},
+            {coalesce_expr} AS {polygon_name},
             {year} AS year,
-            {', '.join([f'sp.spring_{var}' for var in gridmet_vars])},
-            {', '.join([f'su.summer_{var}' for var in gridmet_vars])},
-            {', '.join([f'f.fall_{var}' for var in gridmet_vars])},
-            {', '.join([f'w.winter_{var}' for var in gridmet_vars])}
-        FROM spring_aggregates sp
-        FULL OUTER JOIN summer_aggregates su
-            ON sp.{polygon_name} = su.{polygon_name}
-        FULL OUTER JOIN fall_aggregates f
-            ON COALESCE(sp.{polygon_name}, su.{polygon_name}) = f.{polygon_name}
-        FULL OUTER JOIN winter_aggregates w
-            ON COALESCE(sp.{polygon_name}, su.{polygon_name}, f.{polygon_name}) = w.{polygon_name}
+            {', '.join(select_columns)}
+        {from_clause}
         ORDER BY {polygon_name}
     """)
     

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -1,0 +1,176 @@
+"""
+Create seasonal aggregates from daily gridMET data for a single year.
+
+This script reads daily parquet files and creates seasonal averages for one year:
+- Summer: June 1 - August 31 of the specified year
+- Winter: December 1 (previous year) - February 28/29 (current year)
+
+The logic mirrors the R script that processes temperature data, calculating
+mean values for all gridMET variables by geographic unit and season.
+
+This script is designed to be orchestrated by Snakemake to process multiple years.
+"""
+
+import duckdb
+import hydra
+import logging
+from pathlib import Path
+
+# Configure logger
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+@hydra.main(config_path="../conf", config_name="config", version_base=None)
+def main(cfg):
+    """
+    Create seasonal aggregates for gridMET data for a single year.
+    
+    This function processes daily gridMET data to create summer and winter
+    seasonal averages for all meteorological variables for cfg.year.
+    
+    Args:
+        cfg: Hydra configuration object containing:
+            - year: Year to process (single year)
+            - polygon_name: Geographic identifier column name (e.g., 'zcta', 'county')
+            - datapaths.name: Geographic area name for file paths
+            - snakemake.gridmet_vars: List of gridMET variables to aggregate
+    """
+    geo_name = cfg.datapaths.name
+    polygon_name = cfg.polygon_name
+    gridmet_vars = cfg.snakemake.gridmet_vars
+    year = cfg.year
+    
+    LOGGER.info(f"Creating seasonal aggregates for {geo_name}, year {year}")
+    LOGGER.info(f"Variables: {', '.join(gridmet_vars)}")
+    
+    # Initialize DuckDB connection
+    conn = duckdb.connect()
+    
+    # Check which files we need: current year and previous year (for winter)
+    data_dir = Path(f"data/{geo_name}/output/daily")
+    current_year_file = data_dir / f"meteorology__gridmet__{polygon_name}_daily__{year}.parquet"
+    prev_year_file = data_dir / f"meteorology__gridmet__{polygon_name}_daily__{year - 1}.parquet"
+    
+    if not current_year_file.exists():
+        LOGGER.error(f"Daily file not found for year {year}: {current_year_file}")
+        return
+    
+    # Winter calculation needs previous year's December
+    if not prev_year_file.exists():
+        LOGGER.warning(f"Previous year file not found: {prev_year_file}")
+        LOGGER.warning(f"Winter average for {year} will only include Jan-Feb data")
+        files_to_load = [str(current_year_file)]
+    else:
+        files_to_load = [str(prev_year_file), str(current_year_file)]
+    
+    LOGGER.info(f"Loading daily data from: {files_to_load}")
+    
+    # Load data from the necessary files
+    file_list_str = ", ".join([f"'{f}'" for f in files_to_load])
+    
+    conn.execute(f"""
+        CREATE OR REPLACE VIEW all_daily_data AS
+        SELECT 
+            {polygon_name},
+            date,
+            EXTRACT(YEAR FROM date) AS data_year,
+            EXTRACT(MONTH FROM date) AS month,
+            EXTRACT(DAY FROM date) AS day,
+            {', '.join(gridmet_vars)}
+        FROM read_parquet([{file_list_str}])
+    """)
+    
+    # Check total records
+    total_records = conn.execute("SELECT COUNT(*) FROM all_daily_data").fetchone()[0]
+    LOGGER.info(f"Total daily records loaded: {total_records:,}")
+    
+    # Process summer season (June 1 - August 31) for the current year
+    LOGGER.info(f"Calculating summer {year} averages (June 1 - August 31)...")
+    
+    summer_agg_exprs = [f"AVG({var}) AS summer_{var}" for var in gridmet_vars]
+    
+    conn.execute(f"""
+        CREATE OR REPLACE TABLE summer_aggregates AS
+        SELECT
+            {polygon_name},
+            {year} AS year,
+            {', '.join(summer_agg_exprs)}
+        FROM all_daily_data
+        WHERE data_year = {year}
+          AND month >= 6 AND month <= 8  -- June, July, August
+        GROUP BY {polygon_name}
+    """)
+    
+    summer_count = conn.execute("SELECT COUNT(*) FROM summer_aggregates").fetchone()[0]
+    LOGGER.info(f"Summer aggregates created: {summer_count:,} records")
+    
+    # Process winter season (December previous year - February current year)
+    LOGGER.info(f"Calculating winter {year} averages (Dec {year-1} - Feb {year})...")
+    
+    winter_agg_exprs = [f"AVG({var}) AS winter_{var}" for var in gridmet_vars]
+    
+    # Winter for year Y includes: Dec (Y-1) + Jan-Feb (Y)
+    conn.execute(f"""
+        CREATE OR REPLACE TABLE winter_aggregates AS
+        SELECT
+            {polygon_name},
+            {year} AS year,
+            {', '.join(winter_agg_exprs)}
+        FROM all_daily_data
+        WHERE 
+            (data_year = {year - 1} AND month = 12)  -- December of previous year
+            OR (data_year = {year} AND month <= 2)   -- January and February of current year
+        GROUP BY {polygon_name}
+    """)
+    
+    winter_count = conn.execute("SELECT COUNT(*) FROM winter_aggregates").fetchone()[0]
+    LOGGER.info(f"Winter aggregates created: {winter_count:,} records")
+    
+    # Merge summer and winter data
+    LOGGER.info("Merging summer and winter aggregates...")
+    
+    conn.execute(f"""
+        CREATE OR REPLACE TABLE seasonal_combined AS
+        SELECT
+            COALESCE(s.{polygon_name}, w.{polygon_name}) AS {polygon_name},
+            {year} AS year,
+            {', '.join([f's.summer_{var}' for var in gridmet_vars])},
+            {', '.join([f'w.winter_{var}' for var in gridmet_vars])}
+        FROM summer_aggregates s
+        FULL OUTER JOIN winter_aggregates w
+            ON s.{polygon_name} = w.{polygon_name}
+        ORDER BY {polygon_name}
+    """)
+    
+    combined_count = conn.execute("SELECT COUNT(*) FROM seasonal_combined").fetchone()[0]
+    LOGGER.info(f"Combined seasonal data: {combined_count:,} records")
+    
+    # Show sample of the output
+    LOGGER.info("Sample of seasonal aggregates:")
+    sample = conn.execute("SELECT * FROM seasonal_combined LIMIT 5").fetchdf()
+    LOGGER.info(f"\n{sample.to_string()}")
+    
+    # Create output directory if it doesn't exist
+    output_dir = Path(f"data/{geo_name}/output/seasonal")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Write output to parquet file
+    output_path = output_dir / f"meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet"
+    LOGGER.info(f"Writing output to: {output_path}")
+    
+    conn.execute(f"""
+        COPY seasonal_combined
+        TO '{output_path}'
+        (FORMAT PARQUET)
+    """)
+    
+    LOGGER.info(f"Seasonal aggregates successfully written to {output_path}")
+    
+    # Clean up
+    conn.close()
+    LOGGER.info("Processing complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -1,9 +1,16 @@
 """
 Create seasonal aggregates from daily gridMET data for a single year.
 
-This script reads daily parquet files and creates seasonal averages for one year:
-- Summer: June 1 - August 31 of the specified year
+This script reads daily parquet files and creates seasonal averages based on
+configurable season definitions from conf/seasons.yaml.
+
+Default seasons:
+- Spring: March 1 - May 31
+- Summer: June 1 - August 31
+- Fall: September 1 - November 30
 - Winter: December 1 (previous year) - February 28/29 (current year)
+
+adapted from: https://github.com/NSAPH/National-Causal-Analysis/blob/master/Confounders/earth_engine/code/6_calculate_seasonal_averages.R
 
 The logic mirrors the R script that processes temperature data, calculating
 mean values for all gridMET variables by geographic unit and season.
@@ -21,13 +28,50 @@ logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
 
+def build_season_filter(season_name: str, season_config: dict, year: int) -> str:
+    """
+    Build a SQL WHERE clause filter for a season.
+    
+    Args:
+        season_name: Name of the season (e.g., 'summer', 'winter')
+        season_config: Dictionary with start_month, start_day, end_month, end_day, year_offset
+        year: The year being processed
+    
+    Returns:
+        SQL WHERE clause string
+    """
+    year_offset = season_config.get('year_offset', 0)
+    start_month = season_config['start_month']
+    end_month = season_config['end_month']
+    
+    if year_offset == 0:
+        # Simple case: season within the same year
+        if start_month <= end_month:
+            # Normal season (e.g., summer: June-August)
+            return f"""data_year = {year} 
+              AND month >= {start_month} AND month <= {end_month}"""
+        else:
+            # Season wraps around year boundary within same year (unusual but supported)
+            return f"""data_year = {year} 
+              AND (month >= {start_month} OR month <= {end_month})"""
+    else:
+        # Season spans year boundary (e.g., winter: Dec previous year + Jan-Feb current year)
+        if year_offset == -1:
+            # Previous year contributes to this year's season
+            return f"""(data_year = {year - 1} AND month >= {start_month})
+            OR (data_year = {year} AND month <= {end_month})"""
+        else:
+            LOGGER.warning(f"Unusual year_offset {year_offset} for season {season_name}")
+            return f"data_year = {year} AND month >= {start_month} AND month <= {end_month}"
+
+
 @hydra.main(config_path="../conf", config_name="config", version_base=None)
 def main(cfg):
     """
     Create seasonal aggregates for gridMET data for a single year.
     
-    This function processes daily gridMET data to create summer and winter
-    seasonal averages for all meteorological variables for cfg.year.
+    This function processes daily gridMET data to create seasonal averages
+    based on the seasons defined in cfg.seasons configuration.
     
     Args:
         cfg: Hydra configuration object containing:
@@ -35,16 +79,18 @@ def main(cfg):
             - polygon_name: Geographic identifier column name (e.g., 'zcta', 'county')
             - datapaths.name: Geographic area name for file paths
             - snakemake.gridmet_vars: List of gridMET variables to aggregate
+            - seasons: Dictionary of season definitions with start/end months/days
     """
     geo_name = cfg.datapaths.name
     polygon_name = cfg.polygon_name
     gridmet_vars = cfg.snakemake.gridmet_vars
     year = cfg.year
+    seasons = cfg.seasons
     
     LOGGER.info(f"Creating seasonal aggregates for {geo_name}, year {year}")
     LOGGER.info(f"Variables: {', '.join(gridmet_vars)}")
+    LOGGER.info(f"Seasons configured: {', '.join(seasons.keys())}")
     
-    # Initialize DuckDB connection
     conn = duckdb.connect()
     
     # Check which files we need: current year and previous year (for winter)
@@ -85,61 +131,54 @@ def main(cfg):
     total_records = conn.execute("SELECT COUNT(*) FROM all_daily_data").fetchone()[0]
     LOGGER.info(f"Total daily records loaded: {total_records:,}")
     
-    # Process summer season (June 1 - August 31) for the current year
-    LOGGER.info(f"Calculating summer {year} averages (June 1 - August 31)...")
+    # Process each configured season
+    seasonal_tables = {}
     
-    summer_agg_exprs = [f"AVG({var}) AS summer_{var}" for var in gridmet_vars]
+    for season_name, season_config in seasons.items():
+        LOGGER.info(f"Calculating {season_name} {year} averages...")
+        
+        # Build aggregation expressions
+        agg_exprs = [f"AVG({var}) AS {season_name}_{var}" for var in gridmet_vars]
+        
+        # Build WHERE clause for this season
+        season_filter = build_season_filter(season_name, season_config, year)
+        
+        # Create table for this season
+        table_name = f"{season_name}_aggregates"
+        conn.execute(f"""
+            CREATE OR REPLACE TABLE {table_name} AS
+            SELECT
+                {polygon_name},
+                {year} AS year,
+                {', '.join(agg_exprs)}
+            FROM all_daily_data
+            WHERE {season_filter}
+            GROUP BY {polygon_name}
+        """)
+        
+        count = conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+        LOGGER.info(f"{season_name.capitalize()} aggregates created: {count:,} records")
+        seasonal_tables[season_name] = table_name
     
-    conn.execute(f"""
-        CREATE OR REPLACE TABLE summer_aggregates AS
-        SELECT
-            {polygon_name},
-            {year} AS year,
-            {', '.join(summer_agg_exprs)}
-        FROM all_daily_data
-        WHERE data_year = {year}
-          AND month >= 6 AND month <= 8  -- June, July, August
-        GROUP BY {polygon_name}
-    """)
-    
-    summer_count = conn.execute("SELECT COUNT(*) FROM summer_aggregates").fetchone()[0]
-    LOGGER.info(f"Summer aggregates created: {summer_count:,} records")
-    
-    # Process winter season (December previous year - February current year)
-    LOGGER.info(f"Calculating winter {year} averages (Dec {year-1} - Feb {year})...")
-    
-    winter_agg_exprs = [f"AVG({var}) AS winter_{var}" for var in gridmet_vars]
-    
-    # Winter for year Y includes: Dec (Y-1) + Jan-Feb (Y)
-    conn.execute(f"""
-        CREATE OR REPLACE TABLE winter_aggregates AS
-        SELECT
-            {polygon_name},
-            {year} AS year,
-            {', '.join(winter_agg_exprs)}
-        FROM all_daily_data
-        WHERE 
-            (data_year = {year - 1} AND month = 12)  -- December of previous year
-            OR (data_year = {year} AND month <= 2)   -- January and February of current year
-        GROUP BY {polygon_name}
-    """)
-    
-    winter_count = conn.execute("SELECT COUNT(*) FROM winter_aggregates").fetchone()[0]
-    LOGGER.info(f"Winter aggregates created: {winter_count:,} records")
-    
-    # Merge summer and winter data
-    LOGGER.info("Merging summer and winter aggregates...")
+    # Merge all seasonal data
+    LOGGER.info(f"Merging all {len(seasonal_tables)} seasonal aggregates...")
     
     conn.execute(f"""
         CREATE OR REPLACE TABLE seasonal_combined AS
         SELECT
-            COALESCE(s.{polygon_name}, w.{polygon_name}) AS {polygon_name},
+            COALESCE(sp.{polygon_name}, su.{polygon_name}, f.{polygon_name}, w.{polygon_name}) AS {polygon_name},
             {year} AS year,
-            {', '.join([f's.summer_{var}' for var in gridmet_vars])},
+            {', '.join([f'sp.spring_{var}' for var in gridmet_vars])},
+            {', '.join([f'su.summer_{var}' for var in gridmet_vars])},
+            {', '.join([f'f.fall_{var}' for var in gridmet_vars])},
             {', '.join([f'w.winter_{var}' for var in gridmet_vars])}
-        FROM summer_aggregates s
+        FROM spring_aggregates sp
+        FULL OUTER JOIN summer_aggregates su
+            ON sp.{polygon_name} = su.{polygon_name}
+        FULL OUTER JOIN fall_aggregates f
+            ON COALESCE(sp.{polygon_name}, su.{polygon_name}) = f.{polygon_name}
         FULL OUTER JOIN winter_aggregates w
-            ON s.{polygon_name} = w.{polygon_name}
+            ON COALESCE(sp.{polygon_name}, su.{polygon_name}, f.{polygon_name}) = w.{polygon_name}
         ORDER BY {polygon_name}
     """)
     

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -111,7 +111,7 @@ def main(cfg):
         LOGGER.info(f"Calculating {season_name} {year} averages...")
         
         # Build aggregation expressions
-        agg_exprs = [f"AVG({var}) AS {season_name}_{var}" for var in gridmet_vars]
+        agg_exprs = [f"AVG({var}) AS {var}_{season_name}" for var in gridmet_vars]
         
         # Build WHERE clause for this season
         season_filter = build_season_filter(season_name, season_config, year)
@@ -147,7 +147,7 @@ def main(cfg):
     select_columns = []
     for season_name in season_names:
         season_abbrev = season_name[:2] if len(season_name) >= 2 else season_name[0]
-        select_columns.extend([f'{season_abbrev}.{season_name}_{var}' for var in gridmet_vars])
+        select_columns.extend([f'{season_abbrev}.{var}_{season_name}' for var in gridmet_vars])
     
     # Build COALESCE for polygon_name across all tables
     season_abbrevs = [s[:2] if len(s) >= 2 else s[0] for s in season_names]

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -66,7 +66,7 @@ def main(cfg):
     conn = duckdb.connect()
     
     # Load current year data only
-    data_dir = Path(f"data/{geo_name}/output/daily")
+    data_dir = Path(f"data/{geo_name}/output/core/daily")
     current_year_file = data_dir / f"meteorology__gridmet__{polygon_name}_daily__{year}.parquet"
     
     if not current_year_file.exists():
@@ -172,9 +172,8 @@ def main(cfg):
     LOGGER.info(f"\n{sample.to_string()}")
     
     # Write output to parquet file
-    output_path = output_dir / f"meteorology__gridmet__{polygon_name}_seasonal__{year}.parquet"
+    output_path = f"data/{geo_name}/output/seasonal/yearly/meteorology__gridmet__{cfg.polygon_name}_yearly__{cfg.year}.parquet"
     LOGGER.info(f"Writing output to: {output_path}")
-    
     conn.execute(f"""
         COPY seasonal_combined
         TO '{output_path}'

--- a/src/seasonal_vars.py
+++ b/src/seasonal_vars.py
@@ -104,14 +104,6 @@ def main(cfg):
     total_records = conn.execute("SELECT COUNT(*) FROM all_daily_data").fetchone()[0]
     LOGGER.info(f"Total daily records loaded: {total_records:,}")
     
-    # Log first 10 December dates for verification
-    december_dates = conn.execute("SELECT date FROM all_daily_data WHERE month = 12 ORDER BY date LIMIT 10").fetchall()
-    if december_dates:
-        dates_str = ", ".join([str(d[0]) for d in december_dates])
-        LOGGER.info(f"First 10 December dates: {dates_str}")
-    else:
-        LOGGER.warning("No December dates found in the data")
-    
     # Process each configured season
     seasonal_tables = {}
     


### PR DESCRIPTION
This PR extends the gridMET data processing pipeline to calculate **seasonal meteorological aggregates**. The new functionality creates season-specific averages for all gridMET variables alongside the existing daily and yearly outputs, with configurable season definitions.

### Changes

####  New Features

**1. Seasonal Aggregation Module** ([src/seasonal_vars.py](src/seasonal_vars.py))
- New script to calculate seasonal averages from daily meteorological data
- Processes data based on configurable season definitions
- Uses DuckDB for efficient aggregation across large datasets
- Generates parquet files with season-suffixed variables (e.g., `tmmx_summer`, `pr_winter`)

**2. Configurable Season Definitions** ([conf/seasons.yaml](conf/seasons.yaml))
- New configuration file for flexible season definitions
- Default seasons configured:
  - **Summer**: June, July, August (months 6-8)
  - **Winter**: December, January, February from the same calendar year (months 12, 1, 2)

#### Configuration Updates

**Snakefile** ([Snakefile](Snakefile))
- Added `get_seasonal` rule to process seasonal aggregates
- Updated `all` rule to include seasonal output targets

**Data Paths** ([conf/datapaths/](conf/datapaths/))
- Added seasonal output directories for county and ZCTA configurations

The pipeline now generates three temporal granularities:

1. **Daily**: `core/meteorology__gridmet__{polygon_name}_daily__{year}.parquet`
2. **Yearly**: `core/meteorology__gridmet__{polygon_name}_yearly__{year}.parquet`
3. **Seasonal** (NEW): `seasonal/meteorology__gridmet__{polygon_name}_yearly__{year}.parquet`

Closes #15
